### PR TITLE
Remove .git directories during build.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -47,6 +47,8 @@ parts:
       sed -i.bak -e 's|=org.gnome.Glade$|=snap.$CRAFT_PROJECT_NAME.org.gnome.Glade|g' $CRAFT_PART_SRC/data/org.gnome.Glade.desktop.in.in
       sed -i.bak '\|<id>org.gnome.Glade</id>|a<icon type="stock">snap.$CRAFT_PROJECT_NAME.org.gnome.Glade</icon>' $CRAFT_PART_SRC/data/org.gnome.Glade.appdata.xml.in
       sed -i.bak -e 's|symlink_media: true,|symlink_media: false,|g' $CRAFT_PART_SRC/help/meson.build
+      # Remove .git in order to avoid broken vcs_tag branch in src/meson.build
+      rm -rf $CRAFT_PART_BUILD/.git $CRAFT_PART_SRC/.git || :
       craftctl default
       mkdir -p $CRAFT_PART_INSTALL/meta/gui/
       cp $CRAFT_PART_SRC/data/icons/hicolor/scalable/apps/org.gnome.Glade.svg $CRAFT_PART_INSTALL/meta/gui/icon.svg


### PR DESCRIPTION
## Description

Fix failure to build by removing .git directories before building. They cause the vcs_tag branch of src/meson.build to be taken, and vcs_tag is broken.

An alternative is to [patch that file](https://github.com/nteodosio/glade/commit/d4e32493f10f640be5bf2ce770679e0996e7fcfb).

## Type of change

Please check only the options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

By submitting [builds on Launchpad](https://launchpad.net/~nteodosio/+snap/glade).

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings

